### PR TITLE
Add optional maximum number of tokens

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: clean
+.PHONY: clean test
 
 markov:
 	go build -o markov cmd/markov/main.go
 
 clean:
 	rm markov
+
+test:
+	go test ./...

--- a/cmd/markov/main.go
+++ b/cmd/markov/main.go
@@ -16,6 +16,7 @@ import (
 func main() {
 	var markov generator.Generator
 	prefixLen := flag.Int("n", 1, "number of tokens to use to map following token")
+	maxTokens := flag.Int("max", -1, "maximum number of tokens to generate. a negative number signifies no maximum")
 	genWord := flag.Bool("w", false, "generate a word instead of a sentence")
 	printHelp := flag.Bool("h", false, "print this help message")
 	flag.Parse()
@@ -47,7 +48,11 @@ func main() {
 		markov = sentence.New(strings.Split(feed, "\n"), *prefixLen)
 	}
 
-	fmt.Println(markov.Generate())
+	if *maxTokens < 0 {
+		fmt.Println(markov.Generate())
+	} else {
+		panic("unimplemented")
+	}
 }
 
 func init() {

--- a/cmd/markov/main.go
+++ b/cmd/markov/main.go
@@ -15,6 +15,7 @@ import (
 
 func main() {
 	var markov generator.Generator
+	var err error
 	prefixLen := flag.Int("n", 1, "number of tokens to use to map following token")
 	maxTokens := flag.Int("max", -1, "maximum number of tokens to generate. a negative number signifies no maximum")
 	genWord := flag.Bool("w", false, "generate a word instead of a sentence")
@@ -48,11 +49,19 @@ func main() {
 		markov = sentence.New(strings.Split(feed, "\n"), *prefixLen)
 	}
 
+	var output string
+
 	if *maxTokens < 0 {
-		fmt.Println(markov.Generate())
+		output = markov.Generate()
 	} else {
-		panic("unimplemented")
+		output, err = markov.LimitedGenerate(*maxTokens)
 	}
+
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(output)
 }
 
 func init() {

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -4,4 +4,7 @@ package generator
 type Generator interface {
 	// Generate returns a random output using a Markov chain.
 	Generate() string
+	// LimitedGenerate returns a random output using a markov chain,
+	// with a set maximum number of tokens.
+	LimitedGenerate(maxTokens int) (output string, err error)
 }

--- a/pkg/generator/sentence/sentence_test.go
+++ b/pkg/generator/sentence/sentence_test.go
@@ -1,0 +1,28 @@
+package sentence
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestMaximumHit creates a sentence generator that *would* generate too many tokens,
+// checks that generation stops when the set maximum number of tokens is reached instead.
+func TestMaximumHit(t *testing.T) {
+	generator := New([]string{"a b c d e f g"}, 1)
+	output, err := generator.LimitedGenerate(3)
+	wantedLength := len(strings.Split(output, " "))
+	if wantedLength != 3 || err != nil {
+		t.Fatalf(`LimitedGenerate(3) = %q, %v, want <string of length 3>, nil`, output, err)
+	}
+}
+
+// TestTooSmallMax calls sentence.LimitedGenerate with a maximum that is less than
+// the generator's prefix length, checking for an error.
+func TestTooSmallMax(t *testing.T) {
+	generator := New([]string{"a b c d e f g"}, 3)
+	output, err := generator.LimitedGenerate(2)
+
+	if len(output) != 0 || err == nil {
+		t.Fatalf(`LimitedGenerate(2) = %q, %v, want "", error`, output, err)
+	}
+}

--- a/pkg/generator/word/word_test.go
+++ b/pkg/generator/word/word_test.go
@@ -1,0 +1,25 @@
+package word
+
+import "testing"
+
+// TestMaximumHit creates a word generator that *would* generate too many tokens,
+// checks that generation stops when the set maximum number of tokens is reached instead.
+func TestMaximumHit(t *testing.T) {
+	generator := New([]string{"abcdefg"}, 1)
+	output, err := generator.LimitedGenerate(3)
+	want := "abc"
+	if output != want || err != nil {
+		t.Fatalf(`LimitedGenerate(3) = %q, %v, want %q, nil`, output, err, want)
+	}
+}
+
+// TestTooSmallMax calls word.LimitedGenerate with a maximum that is less than
+// the generator's prefix length, checking for an error.
+func TestTooSmallMax(t *testing.T) {
+	generator := New([]string{"abcdefg"}, 3)
+	output, err := generator.LimitedGenerate(2)
+
+	if len(output) != 0 || err == nil {
+		t.Fatalf(`LimitedGenerate(2) = %q, %v, want "", error`, output, err)
+	}
+}


### PR DESCRIPTION
Allows user to specify a maximum number of tokens that forces generation to stop.