### PR TITLE
Breaking: Remove channel usage

### DIFF
--- a/cmd/markov/main.go
+++ b/cmd/markov/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 var prefixLen = flag.Int("n", 1, "number of tokens to use to map following token")
-var maxTokens = flag.Int("max", 0, "maximum number of tokens to generate. a zero or negative number signifies no maximum")
+var maxTokens = flag.Int("max", -1, "maximum number of tokens to generate. A negative number signifies no maximum")
 var genWord = flag.Bool("w", false, "generate a word instead of a sentence")
 var printHelp = flag.Bool("h", false, "print this help message")
 

--- a/pkg/generator/examples_test.go
+++ b/pkg/generator/examples_test.go
@@ -30,10 +30,8 @@ func Example() {
 		panic(err)
 	}
 
-	c := make(chan []byte)
+	next := g.Generate()
 
-	go g.Generate(c)
-
-	fmt.Println(string(<-c))
+	fmt.Println(string(next()))
 	// Output: Hello,
 }

--- a/pkg/generator/sentence/sentence.go
+++ b/pkg/generator/sentence/sentence.go
@@ -13,13 +13,13 @@ type sentenceGenerator struct {
 
 // Generate returns a random sentence using the Markov chain.
 //
-// If maxTokens is <= 0, then generation will continue until its "natural"
+// If maxTokens is < 0, then generation will continue until its "natural"
 // end from the chain deciding that a token should end the chain.
 // Enforcing a maximum number of tokens can be helpful if the chain has a
 // chance of generating infinitely, or to simply prevent the generated
 // sentence from being overly long.
 func (generator *sentenceGenerator) Generate(maxTokens int) string {
-	if maxTokens < 1 {
+	if maxTokens == 0 {
 		return ""
 	}
 
@@ -33,7 +33,7 @@ func (generator *sentenceGenerator) Generate(maxTokens int) string {
 		builder.WriteByte(b)
 	}
 
-	for i, next := 1, g(); i < maxTokens && next != nil; i++ {
+	for i, next := 1, g(); i != maxTokens && next != nil; i++ {
 		builder.WriteRune(' ')
 		for _, b := range next {
 			builder.WriteByte(b)

--- a/pkg/generator/word/word.go
+++ b/pkg/generator/word/word.go
@@ -21,19 +21,14 @@ type wordGenerator struct {
 // word from being overly long.
 func (generator *wordGenerator) Generate(maxTokens int) string {
 	var builder strings.Builder
-	c := make(chan []byte)
-	tokenCounter := 1
 
-	go generator.generator.Generate(c)
+	g := generator.generator.Generate()
 
-	for bytes := range c {
-		for _, b := range bytes {
+	for i, next := 0, g(); i < maxTokens && next != nil; i++ {
+		for _, b := range next {
 			builder.WriteByte(b)
 		}
-		if tokenCounter == maxTokens {
-			break
-		}
-		tokenCounter++
+		next = g()
 	}
 
 	return builder.String()

--- a/pkg/generator/word/word.go
+++ b/pkg/generator/word/word.go
@@ -14,7 +14,7 @@ type wordGenerator struct {
 
 // Generate returns a random word using the Markov chain.
 //
-// If maxTokens is <= 0, then generation will continue until its "natural"
+// If maxTokens is < 0, then generation will continue until its "natural"
 // end from the chain deciding that a token should end the chain.
 // Enforcing a maximum number of tokens can be helpful if the chain has a
 // chance of generating infinitely, or to simply prevent the generated
@@ -24,7 +24,7 @@ func (generator *wordGenerator) Generate(maxTokens int) string {
 
 	g := generator.generator.Generate()
 
-	for i, next := 0, g(); i < maxTokens && next != nil; i++ {
+	for i, next := 0, g(); i != maxTokens && next != nil; i++ {
 		for _, b := range next {
 			builder.WriteByte(b)
 		}


### PR DESCRIPTION
Return a closure that generates the next token instead of using a channel, to simplify usage.
