### PR TITLE
Always have byte sequence, even if it is empty

### DIFF
--- a/pkg/chain/word.go
+++ b/pkg/chain/word.go
@@ -23,8 +23,12 @@ func (chain *WordChain) Generator() func() (next rune, stop error) {
 		if err != nil {
 			return next, err
 		}
-		next, _ = utf8.DecodeRune(bytes)
+		next, size := utf8.DecodeRune(bytes)
 
+		// NOTE If bytes were empty, empty string was generated
+		if size == 0 {
+			return 0, ErrStopIter
+		}
 		if next == utf8.RuneError {
 			stop = errors.New("Could not decode bytes to rune. Was valid UTF-8 used?")
 		}

--- a/pkg/chain/word.go
+++ b/pkg/chain/word.go
@@ -52,6 +52,11 @@ func NewWordChain(words []string, prefixLen int) (wordChain *WordChain, err erro
 		go func(index int, word string) {
 			defer waiter.Done()
 
+			if len(word) == 0 {
+				bytes[index] = [][]byte{{}}
+				return
+			}
+
 			runes := []rune(word)
 			runesAsBytes := make([][]byte, 0, len(runes))
 


### PR DESCRIPTION
Always makes a byte sequence available by processing an empty string as
```go
[][]byte{{}}
```
when creating a word generator. If an empty byte sequence is returned by the generator,
that is a sign to stop word generation.

Fixes #14 