### PR TITLE
Stop iteration if no next values

### DIFF
--- a/pkg/chain/bytes.go
+++ b/pkg/chain/bytes.go
@@ -28,7 +28,9 @@ func (bytesChain *BytesChain) Generator() func() (next []byte, stop error) {
 
 	return func() (next []byte, stop error) {
 		defer h.Reset()
-		next = lastBytes[0]
+		if len(lastBytes) != 0 {
+			next = lastBytes[0]
+		}
 
 		if next == nil {
 			stop = ErrStopIter


### PR DESCRIPTION
If the array containing the next value is of length `0`, that means that
there are no tokens that can be used to generate the next token, and
that iteration should be stopped.

Fixes #14
Conflicts with #15 